### PR TITLE
decrease the amount of pipelines triggered

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ release, main, dev ]
+    branches: [ dev ]
   pull_request:
-    branches: [ release, main, dev ]
+    branches: [ release ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build:
+  build-and-test:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ An application that calculates the optimal purchases and cooking in order to min
  - to be decided
  - TUI - terminal / text
 
+### Actions:
+ - CMake build&test
+ - build matrix for ubuntu-latest and windows-latest
+
 ## Notes
 ### Dimensions
  - N is the number of recipes


### PR DESCRIPTION
I need to trigger less pipelines with my commits, whilst retaining the ability to test it before release